### PR TITLE
Both LineDef and SideDef can now have lm_sampledist_... properties

### DIFF
--- a/src/level/level_udmf.cpp
+++ b/src/level/level_udmf.cpp
@@ -241,6 +241,11 @@ void FProcessor::ParseThing(IntThing *th)
 
 void FProcessor::ParseLinedef(IntLineDef *ld)
 {
+	ld->sampling.SetGeneralSampleDistance(0);
+	ld->sampling.SetSampleDistance(WallPart::TOP, 0);
+	ld->sampling.SetSampleDistance(WallPart::MIDDLE, 0);
+	ld->sampling.SetSampleDistance(WallPart::BOTTOM, 0);
+
 	std::vector<int> moreids;
 	SC_MustGetStringName("{");
 	while (!SC_CheckString("}"))
@@ -320,6 +325,22 @@ void FProcessor::ParseLinedef(IntLineDef *ld)
 			ld->ids.Clear();
 			if (id != -1) ld->ids.Push(id);
 		}
+		else if (stricmp(key, "lm_sampledist_line") == 0)
+		{
+			ld->sampling.SetGeneralSampleDistance(CheckInt(key));
+		}
+		else if (stricmp(key, "lm_sampledist_top") == 0)
+		{
+			ld->sampling.SetSampleDistance(WallPart::TOP, CheckInt(key));
+		}
+		else if (stricmp(key, "lm_sampledist_mid") == 0)
+		{
+			ld->sampling.SetSampleDistance(WallPart::MIDDLE, CheckInt(key));
+		}
+		else if (stricmp(key, "lm_sampledist_bot") == 0)
+		{
+			ld->sampling.SetSampleDistance(WallPart::BOTTOM, CheckInt(key));
+		}
 
 		if (!stricmp(key, "sidefront"))
 		{
@@ -359,10 +380,10 @@ void FProcessor::ParseSidedef(IntSideDef *sd)
 	sd->midtexture[1] = 0;
 	sd->bottomtexture[0] = '-';
 	sd->bottomtexture[1] = 0;
-	sd->sampleDistance = 0;
-	sd->sampleDistanceTop = 0;
-	sd->sampleDistanceMiddle = 0;
-	sd->sampleDistanceBottom = 0;
+	sd->sampling.SetGeneralSampleDistance(0);
+	sd->sampling.SetSampleDistance(WallPart::TOP, 0);
+	sd->sampling.SetSampleDistance(WallPart::MIDDLE, 0);
+	sd->sampling.SetSampleDistance(WallPart::BOTTOM, 0);
 	while (!SC_CheckString("}"))
 	{
 		const char *value;
@@ -396,19 +417,19 @@ void FProcessor::ParseSidedef(IntSideDef *sd)
 		}
 		else if (stricmp(key, "lm_sampledist_line") == 0)
 		{
-			sd->sampleDistance = CheckInt(key);
+			sd->sampling.SetGeneralSampleDistance(CheckInt(key));
 		}
 		else if (stricmp(key, "lm_sampledist_top") == 0)
 		{
-			sd->sampleDistanceTop = CheckInt(key);
+			sd->sampling.SetSampleDistance(WallPart::TOP, CheckInt(key));
 		}
 		else if (stricmp(key, "lm_sampledist_mid") == 0)
 		{
-			sd->sampleDistanceMiddle = CheckInt(key);
+			sd->sampling.SetSampleDistance(WallPart::MIDDLE, CheckInt(key));
 		}
 		else if (stricmp(key, "lm_sampledist_bot") == 0)
 		{
-			sd->sampleDistanceBottom = CheckInt(key);
+			sd->sampling.SetSampleDistance(WallPart::BOTTOM, CheckInt(key));
 		}
 
 		// now store the key in its unprocessed form

--- a/src/lightmap/levelmesh.cpp
+++ b/src/lightmap/levelmesh.cpp
@@ -686,6 +686,12 @@ int LevelMesh::CreatePlanePortal(FLevel& doomMap, const IntLineDef& srcLine, con
 	return it->second;
 }
 
+int LevelMesh::GetSampleDistance(const IntSideDef& sidedef, WallPart part) const
+{
+	auto sampleDistance = sidedef.GetSampleDistance(part);
+	return sampleDistance ? sampleDistance : defaultSamples;
+}
+
 void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 {
 	IntSector *front;
@@ -744,7 +750,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 			surf->type = ST_MIDDLESIDE;
 			surf->typeIndex = typeIndex;
 			surf->controlSector = nullptr;
-			surf->sampleDimension = (surf->sampleDimension = side->GetSampleDistanceMiddle()) ? surf->sampleDimension : defaultSamples;
+			surf->sampleDimension = GetSampleDistance(*side, WallPart::MIDDLE);
 
 			float texZ = surf->verts[0].z;
 
@@ -796,7 +802,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 		surf->type = ST_MIDDLESIDE;
 		surf->typeIndex = typeIndex;
 		surf->controlSector = nullptr;
-		surf->sampleDimension = (surf->sampleDimension = side->GetSampleDistanceMiddle()) ? surf->sampleDimension : defaultSamples;
+		surf->sampleDimension = GetSampleDistance(*side, WallPart::MIDDLE);
 
 		float texZ = surf->verts[0].z;
 
@@ -843,7 +849,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 			surf->type = ST_MIDDLESIDE;
 			surf->typeIndex = typeIndex;
 			surf->controlSector = xfloor;
-			surf->sampleDimension = (surf->sampleDimension = otherSide->GetSampleDistanceMiddle()) ? surf->sampleDimension : defaultSamples;
+			surf->sampleDimension = GetSampleDistance(*side, WallPart::MIDDLE);
 			surf->verts.resize(4);
 			surf->verts[0].x = surf->verts[2].x = v2.x;
 			surf->verts[0].y = surf->verts[2].y = v2.y;
@@ -918,7 +924,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 				surf->typeIndex = typeIndex;
 				surf->bSky = bSky;
 				surf->controlSector = nullptr;
-				surf->sampleDimension = (surf->sampleDimension = side->GetSampleDistanceBottom()) ? surf->sampleDimension : defaultSamples;
+				surf->sampleDimension = GetSampleDistance(*side, WallPart::BOTTOM);
 
 				float texZ = surf->verts[0].z;
 
@@ -976,7 +982,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 				surf->typeIndex = typeIndex;
 				surf->bSky = bSky;
 				surf->controlSector = nullptr;
-				surf->sampleDimension = (surf->sampleDimension = side->GetSampleDistanceTop()) ? surf->sampleDimension : defaultSamples;
+				surf->sampleDimension = GetSampleDistance(*side, WallPart::TOP);
 
 				float texZ = surf->verts[0].z;
 
@@ -1022,7 +1028,7 @@ void LevelMesh::CreateSideSurfaces(FLevel &doomMap, IntSideDef *side)
 		surf->type = ST_MIDDLESIDE;
 		surf->typeIndex = typeIndex;
 		surf->controlSector = nullptr;
-		surf->sampleDimension = (surf->sampleDimension = side->GetSampleDistanceMiddle()) ? surf->sampleDimension : defaultSamples;
+		surf->sampleDimension = GetSampleDistance(*side, WallPart::MIDDLE);
 
 		float texZ = surf->verts[0].z;
 

--- a/src/lightmap/levelmesh.h
+++ b/src/lightmap/levelmesh.h
@@ -53,6 +53,8 @@ struct FLevel;
 struct ThingLight;
 class FWadWriter;
 
+enum class WallPart;
+
 enum SurfaceType
 {
 	ST_UNKNOWN,
@@ -186,4 +188,6 @@ private:
 
 	int CreateLinePortal(FLevel &doomMap, const IntLineDef& srcLine, const IntLineDef& dstLine);
 	int CreatePlanePortal(FLevel &doomMap, const IntLineDef& srcLine, const IntLineDef& dstLine);
+
+	int GetSampleDistance(const IntSideDef& sidedef, WallPart part) const;
 };


### PR DESCRIPTION
Oddly enough both GZDoom and UDB expected `lm_sampledist_...` on linedefs, while ZDRay only supported those on sidedefs.

Now ZDRay supports both linedefs and sidedefs.

The configuration order from least important to most important is:

1. sampledist in ZDRay info map thing
2. `lm_sampledist_line` in linedef 
3. `lm_sampledist_...` in linedef
4. `lm_sampledist_line` in sidedef
5. `lm_sampledist_...` in sidedef

(I tested this and it seems to work just fine)
