### PR TITLE
Fixed build for Clang on ARM64 arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if(${TARGET_ARCHITECTURE} MATCHES "x86_64")
 	set_source_files_properties(src/nodebuilder/nodebuild_classify_sse1.cpp PROPERTIES COMPILE_FLAGS "${SSE1_ENABLE}")
 	set_source_files_properties(src/nodebuilder/nodebuild_classify_sse2.cpp PROPERTIES COMPILE_FLAGS "${SSE2_ENABLE}")
 else()
-	add_definitions(-DNO_SSE)
+	add_definitions(-DDISABLE_SSE)
 endif()
 
 CHECK_FUNCTION_EXISTS(stricmp STRICMP_EXISTS)

--- a/src/framework/matrix.h
+++ b/src/framework/matrix.h
@@ -29,7 +29,7 @@ typedef double FLOATTYPE;
 typedef float FLOATTYPE;
 #endif
 
-#ifndef NO_SSE
+#ifndef DISABLE_SSE
 #include <emmintrin.h>
 #endif
 
@@ -108,7 +108,7 @@ class VSMatrix {
 
 		FVector4 operator *(const FVector4& v) const
 		{
-			#ifdef NO_SSE
+			#ifdef DISABLE_SSE
 			FVector4 result;
 			result.X = mMatrix[0 * 4 + 0] * v.X + mMatrix[1 * 4 + 0] * v.Y + mMatrix[2 * 4 + 0] * v.Z + mMatrix[3 * 4 + 0] * v.W;
 			result.Y = mMatrix[0 * 4 + 1] * v.X + mMatrix[1 * 4 + 1] * v.Y + mMatrix[2 * 4 + 1] * v.Z + mMatrix[3 * 4 + 1] * v.W;

--- a/src/framework/vectors.h
+++ b/src/framework/vectors.h
@@ -44,6 +44,7 @@
 #include <math.h>
 #include <float.h>
 #include <string.h>
+#include <algorithm>
 
 // this is needed to properly normalize angles. We cannot do that with compiler provided conversions because they differ too much
 #include "xs_Float.h"

--- a/src/lightmapper/hw_collision.cpp
+++ b/src/lightmapper/hw_collision.cpp
@@ -24,7 +24,8 @@
 #include <algorithm>
 #include <functional>
 #include <cfloat>
-#ifndef NO_SSE
+#include <cstdint>
+#ifndef DISABLE_SSE
 #include <immintrin.h>
 #endif
 
@@ -285,7 +286,7 @@ float TriangleMeshShape::intersect_triangle_ray(TriangleMeshShape *shape, const 
 		shape->vertices[shape->elements[start_element + 2]]
 	};
 
-	// Moeller–Trumbore ray-triangle intersection algorithm:
+	// Moellerï¿½Trumbore ray-triangle intersection algorithm:
 
 	FVector3 D = ray.end - ray.start;
 
@@ -784,7 +785,7 @@ static const uint32_t clearsignbitmask[] = { 0x7fffffff, 0x7fffffff, 0x7fffffff,
 
 IntersectionTest::OverlapResult IntersectionTest::ray_aabb(const RayBBox &ray, const CollisionBBox &aabb)
 {
-#ifndef NO_SSE
+#ifndef DISABLE_SSE
 
 	__m128 v = _mm_loadu_ps(&ray.v.X);
 	__m128 w = _mm_loadu_ps(&ray.w.X);

--- a/src/lightmapper/hw_collision.h
+++ b/src/lightmapper/hw_collision.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "Framework/vectors.h"
+#include "framework/vectors.h"
 #include <vector>
 #include <cmath>
 

--- a/src/lightmapper/vk_lightmap.cpp
+++ b/src/lightmapper/vk_lightmap.cpp
@@ -3,7 +3,7 @@
 #include "vk_renderdevice.h"
 #include "vk_raytrace.h"
 #include "zvulkan/vulkanbuilders.h"
-#include "Framework/halffloat.h"
+#include "framework/halffloat.h"
 #include "framework/zstring.h"
 #include <map>
 

--- a/src/lightmapper/vk_raytrace.h
+++ b/src/lightmapper/vk_raytrace.h
@@ -3,7 +3,7 @@
 
 #include "zvulkan/vulkanobjects.h"
 #include "hw_levelmesh.h"
-#include "Framework/matrix.h"
+#include "framework/matrix.h"
 
 class VulkanRenderDevice;
 


### PR DESCRIPTION
Hello everyone. 
When building ZDRay on Apple M2, I've noticed that the SSE flag was incorrect in `Cmakelists`. Also, had to add one more include in `vectors.h` and `hw_collision.cpp`. 
Additonally, Linux-family does not seem to treat paths in include as case-insensitive. So, I lower-case'd the `framework` dir case in a few places. 

All the CI targets are green now. 
Thank you. 
